### PR TITLE
Added glass chams

### DIFF
--- a/CSGOSimple/features/chams.cpp
+++ b/CSGOSimple/features/chams.cpp
@@ -70,7 +70,7 @@ Chams::Chams()
     materialFlatIgnoreZ    = g_MatSystem->FindMaterial("simple_flat_ignorez", TEXTURE_GROUP_MODEL);
     materialFlat           = g_MatSystem->FindMaterial("simple_flat", TEXTURE_GROUP_MODEL);
 }
-
+	
 Chams::~Chams()
 {
     std::remove("csgo\\materials\\simple_regular.vmt");
@@ -79,7 +79,7 @@ Chams::~Chams()
     std::remove("csgo\\materials\\simple_flat_ignorez.vmt");
 }
 
-void Chams::OverrideMaterial(bool ignoreZ, bool flat, bool wireframe, const Color& rgba)
+void Chams::OverrideMaterial(bool ignoreZ, bool flat, bool wireframe, bool glass, const Color& rgba)
 {
     IMaterial* material = nullptr;
 
@@ -88,16 +88,23 @@ void Chams::OverrideMaterial(bool ignoreZ, bool flat, bool wireframe, const Colo
             material = materialFlatIgnoreZ;
         else
             material = materialFlat;
-    } else {
+	} else {
         if(ignoreZ)
             material = materialRegularIgnoreZ;
         else
             material = materialRegular;
     }
 
+
+	if(glass) {
+		material = materialFlat;
+		material->AlphaModulate(0.45f);
+	} else {
+		material->AlphaModulate(
+			rgba.a() / 255.0f);
+	}
+
     material->SetMaterialVarFlag(MATERIAL_VAR_WIREFRAME, wireframe);
-    material->AlphaModulate(
-        rgba.a() / 255.0f);
     material->ColorModulate(
         rgba.r() / 255.0f,
         rgba.g() / 255.0f,
@@ -140,18 +147,21 @@ void Chams::OnDrawModelExecute(
                     true,
                     g_Options.chams_player_flat,
                     g_Options.chams_player_wireframe,
+					false,
                     clr_back);
                 fnDME(g_MdlRender, ctx, state, info, matrix);
                 OverrideMaterial(
                     false,
                     g_Options.chams_player_flat,
                     g_Options.chams_player_wireframe,
+					false,
                     clr_front);
             } else {
                 OverrideMaterial(
                     false,
                     g_Options.chams_player_flat,
                     g_Options.chams_player_wireframe,
+					g_Options.chams_player_glass,
                     clr_front);
             }
         }
@@ -182,18 +192,21 @@ void Chams::OnDrawModelExecute(
                     true,
                     g_Options.chams_arms_flat,
                     g_Options.chams_arms_wireframe,
+					false,
                     g_Options.color_chams_arms_occluded);
                 fnDME(g_MdlRender, ctx, state, info, matrix);
                 OverrideMaterial(
                     false,
                     g_Options.chams_arms_flat,
                     g_Options.chams_arms_wireframe,
+					false,
                     g_Options.color_chams_arms_visible);
             } else {
                 OverrideMaterial(
                     false,
                     g_Options.chams_arms_flat,
                     g_Options.chams_arms_wireframe,
+					g_Options.chams_arms_glass,
                     g_Options.color_chams_arms_visible);
             }
         }

--- a/CSGOSimple/features/chams.hpp
+++ b/CSGOSimple/features/chams.hpp
@@ -25,10 +25,10 @@ public:
         matrix3x4_t *pCustomBoneToWorld);
 
 private:
-    void OverrideMaterial(bool ignoreZ, bool flat, bool wireframe, const Color& rgba);
+    void OverrideMaterial(bool ignoreZ, bool flat, bool wireframe, bool glass, const Color& rgba);
 
     IMaterial* materialRegular          = nullptr;
     IMaterial* materialRegularIgnoreZ   = nullptr;
     IMaterial* materialFlatIgnoreZ      = nullptr;
-    IMaterial* materialFlat             = nullptr;
+	IMaterial* materialFlat             = nullptr;
 };

--- a/CSGOSimple/menu.cpp
+++ b/CSGOSimple/menu.cpp
@@ -186,7 +186,7 @@ void RenderEspTab()
             ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2{ style.WindowPadding.x, style.ItemSpacing.y });
             ImGui::Columns(3, NULL, false);
             ImGui::SetColumnOffset(1, group_w / 3.0f);
-            ImGui::SetColumnOffset(2, 2 * group_w / 3.0f);
+            ImGui::SetColumnOffset(2, 2 * group_w / 2.9f);
             ImGui::SetColumnOffset(3, group_w);
 
             ImGui::BeginGroupBox("Players");
@@ -195,7 +195,8 @@ void RenderEspTab()
                 ImGui::Checkbox("Team Check", &g_Options.chams_player_enemies_only);
                 ImGui::Checkbox("Wireframe", &g_Options.chams_player_wireframe);
                 ImGui::Checkbox("Flat", &g_Options.chams_player_flat);
-                ImGui::Checkbox("Ignore-Z", &g_Options.chams_player_ignorez);
+				ImGui::Checkbox("Ignore-Z", &g_Options.chams_player_ignorez); ImGui::SameLine();
+				ImGui::Checkbox("Glass", &g_Options.chams_player_glass);
                 ImGui::ColorEditMode(ImGuiColorEditMode_HEX);
                 ImGui::PushItemWidth(110);
                 ImGuiEx::ColorEdit4("Ally (Visible)", &g_Options.color_chams_player_ally_visible);
@@ -214,6 +215,7 @@ void RenderEspTab()
                 ImGui::Checkbox("Wireframe", &g_Options.chams_arms_wireframe);
                 ImGui::Checkbox("Flat", &g_Options.chams_arms_flat);
                 ImGui::Checkbox("Ignore-Z", &g_Options.chams_arms_ignorez);
+				ImGui::Checkbox("Glass", &g_Options.chams_arms_glass);
                 ImGui::ColorEditMode(ImGuiColorEditMode_HEX);
                 ImGui::PushItemWidth(110);
                 ImGuiEx::ColorEdit4("Color (Visible)", &g_Options.color_chams_arms_visible);

--- a/CSGOSimple/options.hpp
+++ b/CSGOSimple/options.hpp
@@ -42,11 +42,13 @@ public:
     OPTION(bool, chams_player_enemies_only, false);
     OPTION(bool, chams_player_wireframe,    true);
     OPTION(bool, chams_player_flat,         true);
-    OPTION(bool, chams_player_ignorez,      true);
+	OPTION(bool, chams_player_ignorez,      true);
+	OPTION(bool, chams_player_glass,        false);
     OPTION(bool, chams_arms_enabled,        true);
-    OPTION(bool, chams_arms_wireframe,      true);
+    OPTION(bool, chams_arms_wireframe,      false);
     OPTION(bool, chams_arms_flat,           false);
-    OPTION(bool, chams_arms_ignorez,        false);
+	OPTION(bool, chams_arms_ignorez,        false);
+	OPTION(bool, chams_arms_glass,          true);
 
     //
     // MISC


### PR DESCRIPTION
I was going to use `models\\inventory_items\\cologne_prediction\\cologne_prediction_glass` but managed to get a better effect by changing the alpha of flat chams. Glass is now a setting that will force flat and 45% alpha regardless of other settings.

Solves #44.