### PR TITLE
Added NetVar m_flFlashDuration

### DIFF
--- a/CSGOSimple/valve_sdk/csgostructs.hpp
+++ b/CSGOSimple/valve_sdk/csgostructs.hpp
@@ -231,6 +231,7 @@ public:
     NETVAR(bool,                             m_bHasHelmet,           "DT_CSPlayer", "m_bHasHelmet");
     NETVAR(bool,                             m_bIsScoped,            "DT_CSPlayer", "m_bIsScoped");;
     NETVAR(float,                            m_flLowerBodyYawTarget, "DT_CSPlayer", "m_flLowerBodyYawTarget");
+    NETVAR(float,			     m_flFlashDuration,      "DT_CSPlayer", "m_flFlashDuration");
     NETVAR(int32_t,                          m_iHealth,              "DT_BasePlayer", "m_iHealth");
     NETVAR(int32_t,                          m_lifeState,            "DT_BasePlayer", "m_lifeState");
     NETVAR(int32_t,                          m_fFlags,               "DT_BasePlayer", "m_fFlags");


### PR DESCRIPTION
I have added m_flFlashDuration to the NetVar list.  It is just 1 line, and it will allow users of the base to develop Features like NoFlash, Aimbot (if they are checking if the player is flashed), or adding Flash Information to the ESP. This would be extremely easy to add for anyone with minimal experience, but I believe the idea of this base was to make it Beginner-Friendly.  Moreover, they would still need to code their own features using it so I think it's a good addition.
You probably just forgot about it :)